### PR TITLE
Explictly specify [[bin]] target in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ include = ["git-gone.1", "git-gone.1.adoc"]
 [dependencies]
 clap = "^2"
 
+[[bin]]
+name = "git-gone"
+path = "src/main.rs"
+
 [dependencies.git2]
 version = "^0.13"
 # Disable all features of git2; we only use a small subset of the library and do not need any of these.


### PR DESCRIPTION
Cargo has been unable to install git-gone since v0.3.0 in my environment.
Cargo consistently fails with:

  no targets specified in the manifest
  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be pres

Explictly specifying a [[bin]] target seems to fix the issue.

Fixes #12